### PR TITLE
Adding support for Cordova v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "android-referrer-plugin",
+  "version": "1.0.0",
+  "description": "This plugin captures the referrer value passed when an android app is installed from a webpage and stores it in the applications shared preferences for later retrieval",
+  "cordova": {
+    "id": "com.eightz.mobile.cordova.plugin.android.referrer",
+    "platforms": [
+      "android",
+      "ios"
+    ]
+  },
+  "keywords": [
+    "android",
+    "cordova",
+    "referrer",
+    "plugin"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "cordova": {
     "id": "com.eightz.mobile.cordova.plugin.android.referrer",
     "platforms": [
-      "android",
-      "ios"
+      "android"
     ]
   },
   "keywords": [


### PR DESCRIPTION
Starting with Cordova 7.0, plugins are required to include package.json

More info: https://cordova.apache.org/news/2017/05/04/cordova-7.html